### PR TITLE
Add 'archive-github-repository' script

### DIFF
--- a/archive-github-repository.rb
+++ b/archive-github-repository.rb
@@ -1,0 +1,11 @@
+class ArchiveGithubRepository < Formula
+  desc 'Archive public and private GitHub repositories, including issues, and wiki.'
+  homepage 'https://github.com/koenrh/shell-scripts'
+  url 'https://github.com/koenrh/shell-scripts.git'
+  version '0.1'
+  sha256 '0f7d8352f1ae71320bcb838f5ca415b6313bf86ba51abb4c5209e1edc68009ae'
+
+  def install
+    bin.install 'archive-github-repository'
+  end
+end


### PR DESCRIPTION
Adds `archive-github-repository`, which allows you to archive a GitHub repository, including source code, issues, and wiki pages.