### PR TITLE
Bump 'github-bundle-audit' version to v0.1.2

### DIFF
--- a/github-bundle-audit.rb
+++ b/github-bundle-audit.rb
@@ -1,9 +1,11 @@
 class GithubBundleAudit < Formula
+  depends_on 'jq'
+
   desc 'Audit Gemfiles in a single GitHub repository or all repositories in a GitHub organisation.'
   homepage 'https://github.com/koenrh/shell-scripts'
   url 'https://github.com/koenrh/shell-scripts.git'
-  version '0.1.1'
-  sha256 'd9159ddb22ddca44560555252797f7c69cb77e5ecf3f5a1943223c17f41fd873'
+  version '0.1.2'
+  sha256 'bf50c8a460ac61d19ed97a8456df5e9642e664bc4170aea4f3fa34c7066ba4e6'
 
   def install
     bin.install 'github-bundle-audit'


### PR DESCRIPTION
Adds pagination support to `github-bundle-audit`. See https://github.com/koenrh/shell-scripts/pull/10.